### PR TITLE
clarify license terms

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,20 @@ made”.
 Note that uses of the Logo must also abide by the trademark rules,
 described below.
 
+### Trademark
+
+**Note that use of the Rust logos, and the Rust and Cargo names, is
+also governed by trademark.** Our trademark policy is [described in
+full on the Rust website][legal], but the summary is as follows:
+
+[legal]: https://www.rust-lang.org/policies/media-guide
+
+> TL;DR: Most non-commercial uses of the Rust/Cargo names and logos
+> are allowed and do not require permission; most commercial uses
+> require permission. In either case, the most important rule is that
+> uses of the trademarks cannot appear official or imply any
+> endorsement by the Rust project.
+
 ## Licensing terms for the RustConf artwork
 
 The RustConf artwork is distributed under a [Creative Commons
@@ -26,23 +40,7 @@ distributing derived works.
 
 [CC-BY-NC-ND]: https://creativecommons.org/licenses/by-nc-nd/4.0/
 
-Note that uses of the RustConf artwork must also abide by the
-trademark rules, described below.
-
-## Trademark
-
-**Note that use of this artwork, the Rust logos, and the Rust and
-Cargo names, is also governed by trademark.** Our trademark policy is
-[described in full on the Rust website][legal],
-but the summary is as follows:
-
-[legal]: https://www.rust-lang.org/policies/media-guide
-
-> TL;DR: Most non-commercial uses of the Rust/Cargo names and logos
-> are allowed and do not require permission; most commercial uses
-> require permission. In either case, the most important rule is that
-> uses of the trademarks cannot appear official or imply any
-> endorsement by the Rust project.
+The RustConf artwork is owned by [Tilde](https://www.tilde.io/).
 
 ## Other uses
 

--- a/README.md
+++ b/README.md
@@ -1,13 +1,35 @@
 # rust-artwork
 
-Official artwork for the Rust project. This artwork is distributed
-under the terms of the [Creative Commons Attribution license
-(CC-BY)][CC-BY]. This is the most permissive Creative Commons license, and
-allows reuse and modifications for any purpose. The restrictions are
-that distributors must “give appropriate credit, provide a link to the
-license, and indicate if changes were made”. 
+Official artwork for the Rust project.
+
+## Licensing terms for the Rust logo
+
+The Rust logo is distributed under the terms of the [Creative Commons
+Attribution license (CC-BY)][CC-BY]. This is the most permissive
+Creative Commons license, and allows reuse and modifications for any
+purpose. The restrictions are that distributors must “give appropriate
+credit, provide a link to the license, and indicate if changes were
+made”.
 
 [CC-BY]: https://creativecommons.org/licenses/by/4.0/
+
+Note that uses of the Logo must also abide by the trademark rules,
+described below.
+
+## Licensing terms for the RustConf artwork
+
+The RustConf artwork is distributed under a [Creative Commons
+Attribute-NonCommercial-NoDerivatives][CC-BY-NC-ND] license. This
+license permits you to reproduce the work as-is for noncommercial
+purposes, with attribution, but does not permit creating or
+distributing derived works.
+
+[CC-BY-NC-ND]: https://creativecommons.org/licenses/by-nc-nd/4.0/
+
+Note that uses of the RustConf artwork must also abide by the
+trademark rules, described below.
+
+## Trademark
 
 **Note that use of this artwork, the Rust logos, and the Rust and
 Cargo names, is also governed by trademark.** Our trademark policy is
@@ -21,3 +43,10 @@ but the summary is as follows:
 > require permission. In either case, the most important rule is that
 > uses of the trademarks cannot appear official or imply any
 > endorsement by the Rust project.
+
+## Other uses
+
+If you would like to use the artwork in a way that is not covered by
+the license and trademark rules given above, it may still be
+permitted; e-mail the `trademark@rust-lang.org` address to ask
+permission.


### PR DESCRIPTION
This pull request clarifies the license terms for the RustConf related artwork. Because that artwork is so closely associated with the RustConf brand, and because it features a human character ("Lucy") that is closely associated with RustConf, we do not want to permit derived works (at least, not without permission). We would like to be careful, for example, about the poses and scenes where "Lucy" appears.

This request also clarifies how the license and trademark rules apply (namely, that both must be satisfied).